### PR TITLE
Fix inconsitently returned build count between DotCi and Jenkins default

### DIFF
--- a/src/main/java/com/groupon/jenkins/branchhistory/BranchHistoryWidget.java
+++ b/src/main/java/com/groupon/jenkins/branchhistory/BranchHistoryWidget.java
@@ -43,7 +43,7 @@ import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 
 public class BranchHistoryWidget<T extends DbBackedBuild> extends BuildHistoryWidget<T> {
 
-    protected static final int BUILD_COUNT = 30;
+    protected static final int BUILD_COUNT = 100;
     protected static final String MY_BUILDS_BRANCH = "mine";
     private final String branch;
     private final BranchHistoryWidgetModel<T> model;

--- a/src/main/java/com/groupon/jenkins/branchhistory/BranchHistoryWidget.java
+++ b/src/main/java/com/groupon/jenkins/branchhistory/BranchHistoryWidget.java
@@ -43,7 +43,7 @@ import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 
 public class BranchHistoryWidget<T extends DbBackedBuild> extends BuildHistoryWidget<T> {
 
-    protected static final int BUILD_COUNT = 100;
+    protected static final int BUILD_COUNT = 30;
     protected static final String MY_BUILDS_BRANCH = "mine";
     private final String branch;
     private final BranchHistoryWidgetModel<T> model;

--- a/src/main/java/com/groupon/jenkins/dynamic/build/DbBackedRunList.java
+++ b/src/main/java/com/groupon/jenkins/dynamic/build/DbBackedRunList.java
@@ -108,7 +108,7 @@ public class DbBackedRunList<P extends DbBackedProject<P, B>, B extends DbBacked
 
     @Override
     public Iterator<R> iterator() {
-        return dynamicBuildRepository.<R> latestBuilds(project, 20).iterator();
+        return dynamicBuildRepository.<R> latestBuilds(project, 100).iterator();
     }
 
 }


### PR DESCRIPTION
Jenkins has a built in Limit for API queries of returning only 100 builds
https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Job.java#L691

This is an issue with DotCi, as it only returns 20 last builds via API search.
This commit bumps up the number of builds to be returned via the API search to match Jenkins

If you disagree with this change, I do not mind reverting the change in BuildHistoryWidget.java, but the change in DbBackedRunList.java is needed.