### PR TITLE
use single quotes when echoing shell commands 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,5 +306,10 @@ THE SOFTWARE.
             <version>1.7.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>15.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/groupon/jenkins/buildtype/util/shell/ShellCommands.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/util/shell/ShellCommands.java
@@ -31,6 +31,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Stack;
 import java.util.regex.Pattern;
+
+import com.google.common.escape.Escaper;
+import com.google.common.escape.Escapers;
 import org.apache.commons.lang.StringUtils;
 
 public class ShellCommands {
@@ -71,11 +74,18 @@ public class ShellCommands {
     }
 
     private String echoCommand(String command) {
-        return "echo $ \" " + escapeForShell(command) + "\"";
+        return "echo $ ' " + escapeForShell(command) + "'";
+    }
+
+    public static final Escaper SHELL_ESCAPE;
+    static {
+        final Escapers.Builder builder = Escapers.builder();
+        builder.addEscape('\'', "'\"'\"'");
+        SHELL_ESCAPE = builder.build();
     }
 
     private String escapeForShell(String command) {
-        return command.replaceAll("\"", "\\\\\"");
+        return SHELL_ESCAPE.escape((String) command);
     }
 
     public Pattern regexp(String re) {

--- a/src/test/java/com/groupon/jenkins/buildtype/util/shell/ShellCommandsTest.java
+++ b/src/test/java/com/groupon/jenkins/buildtype/util/shell/ShellCommandsTest.java
@@ -31,6 +31,6 @@ public class ShellCommandsTest {
     public void should_escape_quotes_in_echo() {
         ShellCommands executionPhase = new ShellCommands("echo \"hello\"", "echo world");
         String[] commands = executionPhase.toShellScript().split("\\r?\\n");
-        Assert.assertEquals("echo $ \" echo \\\"hello\\\"\"", commands[0]);
+        Assert.assertEquals("echo $ \' echo \"hello\"\'", commands[0]);
     }
 }


### PR DESCRIPTION
use single quotes when echoing shell commands to avoid premature evaluation of shell logic