### PR TITLE
add docker build caching step to git checkout

### DIFF
--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/DockerComposeBuild.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/DockerComposeBuild.java
@@ -86,6 +86,7 @@ public class DockerComposeBuild extends BuildType implements SubBuildRunner {
                shellCommands.add(format("git fetch origin %s",dotCiEnvVars.get("DOTCI_BRANCH")));
             }
             shellCommands.add(format("git reset --hard  %s", dotCiEnvVars.get("SHA")));
+            shellCommands.add("( for dockerfile in $(find . -name '*Dockerfile*'); do dockerfileName=$(basename $dockerfile) ; dockerfilePath=$(dirname $dockerfile); pushd $dockerfilePath >/dev/null ; for filename in $(grep ADD $dockerfileName | sed -e 's/^\\s*ADD\\s*//g' ; grep COPY $dockerfileName | sed -e 's/^\\s*COPY\\s*//g' ); do test -d $filename && continue ; test -f $filename || continue ; sha=$(git rev-list -n 1 HEAD $filename) ; touch -d \"$(git show -s --format=%ai $sha)\" $filename ; popd >/dev/null ; done ; done ) || true # Set modified time of files added in Dockerfiles to allow for build caching");
         }
         return shellCommands;
     }


### PR DESCRIPTION
works as advertised in test case. doesn't add much to the build time. in theory it shouldn't ever cause a build failure even if it breaks