### PR TITLE
remove unnecessary docker-compose build

### DIFF
--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -73,7 +73,6 @@ public class BuildConfiguration {
         shellCommands.add(checkoutCommands);
         shellCommands.add(String.format("trap \"docker-compose -p %s kill; docker-compose -p %s rm --force; exit\" PIPE QUIT INT HUP EXIT TERM",projectName,projectName));
         shellCommands.add(String.format("docker-compose -p %s pull",projectName));
-        shellCommands.add(String.format("docker-compose -p %s build",projectName));
         if (config.get("run") != null) {
             Map runConfig = (Map) config.get("run");
             Object dockerComposeCommand = runConfig.get(dockerComposeContainerName);


### PR DESCRIPTION
We don't need to build every time, docker-compose run will build what it needs to