### PR TITLE
use https instead of git url to git clone repo

### DIFF
--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/DockerComposeBuild.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/DockerComposeBuild.java
@@ -88,7 +88,7 @@ public class DockerComposeBuild extends BuildType implements SubBuildRunner {
     public ShellCommands getCheckoutCommands(Map<String, Object> dotCiEnvVars) {
         GitUrl gitRepoUrl = new GitUrl((String) dotCiEnvVars.get("GIT_URL"));
         boolean isPrivateRepo = Boolean.parseBoolean((String) dotCiEnvVars.get("DOTCI_IS_PRIVATE_REPO"));
-        String gitUrl = gitRepoUrl.getGitUrl();
+        String gitUrl = isPrivateRepo ? gitRepoUrl.getGitUrl() : gitRepoUrl.getHttpsUrl();
         ShellCommands shellCommands = new ShellCommands();
         shellCommands.add("chmod -R u+w . ; find . ! -path \"./deploykey_rsa.pub\" ! -path \"./deploykey_rsa\" -delete");
         shellCommands.add("git init");

--- a/src/main/java/com/groupon/jenkins/dynamic/build/DynamicBuildModel.java
+++ b/src/main/java/com/groupon/jenkins/dynamic/build/DynamicBuildModel.java
@@ -103,8 +103,13 @@ public class DynamicBuildModel {
     public Map<String, String> getDotCiEnvVars() {
         Map<String, String> vars = new HashMap<String, String>();
         vars.put("SHA", build.getSha());
-        vars.put("GIT_URL", new GitUrl(build.getParent().getGithubRepoUrl()).getUrl());
-        vars.put("DOTCI_IS_PRIVATE_REPO", new Boolean(build.isPrivateRepo()).toString()) ;
+        if (build.isPrivateRepo()) {
+          vars.put("GIT_URL", new GitUrl(build.getParent().getGithubRepoUrl()).getUrl()) ;
+          vars.put("DOTCI_IS_PRIVATE_REPO", "true") ;
+        } else {
+          vars.put("GIT_URL", build.getParent().getGithubRepoUrl()) ;
+          vars.put("DOTCI_IS_PRIVATE_REPO", "false") ;
+        }
         return vars;
     }
 


### PR DESCRIPTION
ssh keys to github repo are also not necessary if interacting via https as read-only

Also recommend using JNLP slaves for the same reason to ease setup.

This should resolve https://github.com/groupon/DotCi/issues/139
