### PR TITLE
Add docker development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+target/
+work/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM maven:3
+
+# https://github.com/joyent/docker-node/blob/master/0.10/Dockerfile
+# verify gpg and sha256: http://nodejs.org/dist/v0.10.31/SHASUMS256.txt.asc
+# gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
+# gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+
+ENV NODE_VERSION 0.10.40
+ENV NPM_VERSION 2.13.2
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --verify SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
+  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
+  && npm install -g npm@"$NPM_VERSION" \
+  && npm cache clear

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM maven:3
 
+RUN apt-get update && apt-get install -y -q build-essential && \
+  rm -rf /var/lib/apt/lists/*
+
 # https://github.com/joyent/docker-node/blob/master/0.10/Dockerfile
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.31/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 
-ENV NODE_VERSION 0.10.40
-ENV NPM_VERSION 2.13.2
+ENV NODE_VERSION 0.12.7
+ENV NPM_VERSION 2.13.3
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+mongo:
+  image: mongo:3
+
+mavendata:
+  image: ubuntu:14.04
+  volumes:
+    - ~/.m2:/root/.m2
+    - ~/.ivy2:/root/.ivy2
+
+plugin:
+  build: .
+  volumes_from:
+    - mavendata
+  volumes:
+    - .:/code
+  links:
+    - mongo
+  working_dir: /code
+  ports:
+    - "8080:8080"
+  environment:
+    MAVEN_OPTS: "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000,suspend=n"
+  command: mvn hpi:run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,5 +19,6 @@ plugin:
   ports:
     - "8080:8080"
   environment:
+    BOWER_ALLOW_ROOT: true
     MAVEN_OPTS: "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000,suspend=n"
   command: mvn hpi:run

--- a/docs/DevelopmentSetup.md
+++ b/docs/DevelopmentSetup.md
@@ -1,16 +1,25 @@
 # Setting up local development environment
 
-* Install mongodb
 * Register an [oauth application with github](https://github.com/settings/applications/new) with the following values
    * Homepage URL - http://127.0.0.1:8080
    * Authorization callback URL - http://127.0.0.1:8080/jenkins/securityRealm/finishLogin
-* Launch local instance with `mvn hpi:run`
+* Install pre-requisites:
+  * Non-docker:
+    * Install mongodb
+  * Docker:
+    * Install docker: https://docs.docker.com/mac/started/
+    * Install docker-compose: https://docs.docker.com/compose/install/
+    * Run build `docker-compose build`
+* Run plugin
+  * Non-docker: `mvn hpi:run`
+  * Docker: `docker-compose up plugin`
 *  Go to `Manage Jenkins` > `Configure Global Security`
-  Under `Security Realm` select `Github Authentication Plugin` and fill out required oauth credentials.  
-*   Got to `Manage Jenkins`> `Configure System` and fill out required information under DotCi Configuration  
-* Optionally add a noop `install_packages` in your `.bash_profile`
-   ```bash
-   install_packages(){  
-     echo "installing packages"
-   }
-    ```
+  * Under `Security Realm` select `Github Authentication Plugin` and fill out required oauth credentials.
+*  Go to `Manage Jenkins`> `Configure System`
+  * Fill out required information under DotCi Configuration
+* Optionally add a noop `install_packages` in your `.bash_profile`:
+  ```bash
+  install_packages(){
+    echo "installing packages"
+  }
+  ```

--- a/docs/DevelopmentSetup.md
+++ b/docs/DevelopmentSetup.md
@@ -10,6 +10,9 @@
     * Install docker: https://docs.docker.com/mac/started/
     * Install docker-compose: https://docs.docker.com/compose/install/
     * Run build `docker-compose build`
+* Prepare assets:
+  * Non-docker: `npm run build`
+  * Docker: `docker-compose run --rm plugin npm run build`
 * Run plugin
   * Non-docker: `mvn hpi:run`
   * Docker: `docker-compose up plugin`

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "lint": "eslint src/main/jsx/**/*",
     "watch": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.config.dev.js --colors --progress --hot --inline  --port  3000",
     "test": "karma start",
-    "vulcanize": "curdir=$(pwd) && cd src/main/webapp && bower install && $(npm bin)/vulcanize webcomponent-imports.html > webcomponent-imports-vulcanized.html && cd $curdir"
+    "vulcanize": "curdir=$(pwd) && cd src/main/webapp && bower install --config.interactive=false && $(npm bin)/vulcanize webcomponent-imports.html > webcomponent-imports-vulcanized.html && cd $curdir"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "lint": "eslint src/main/jsx/**/*",
     "watch": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.config.dev.js --colors --progress --hot --inline  --port  3000",
     "test": "karma start",
-    "vulcanize": "pushd src/main/webapp && bower install && $(npm bin)/vulcanize webcomponent-imports.html > webcomponent-imports-vulcanized.html && popd"
-
+    "vulcanize": "curdir=$(pwd) && cd src/main/webapp && bower install && $(npm bin)/vulcanize webcomponent-imports.html > webcomponent-imports-vulcanized.html && cd $curdir"
   }
 }


### PR DESCRIPTION
Related to https://github.com/groupon/DotCi/issues/146

The development instructions are a bit sparse, and there are lots of dependencies (mongo, maven, npm) that people might not always want to install. This introduces docker support around development so a person can do:
```
docker-compose build
docker-compose run --rm plugin npm run build
docker-compose up plugin
```
And have all the things running. There are probably some gaps here around how people do development around code reloading, asset recompilation, etc. but I think its a good starting spot to start fleshing out a more predictable development environment.