### PR TITLE
add flag --rm to Remove container after run. Ignored in detached mode.

### DIFF
--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -78,10 +78,10 @@ public class BuildConfiguration {
             Map runConfig = (Map) config.get("run");
             Object dockerComposeCommand = runConfig.get(dockerComposeContainerName);
             if (dockerComposeCommand != null ) {
-                shellCommands.add(String.format("docker-compose -f %s -p %s run -T %s sh -xc '%s'", fileName, projectName, dockerComposeContainerName,SHELL_ESCAPE.escape((String) dockerComposeCommand)));
+                shellCommands.add(String.format("docker-compose -f %s -p %s run --rm -T %s sh -xc '%s'", fileName, projectName, dockerComposeContainerName,SHELL_ESCAPE.escape((String) dockerComposeCommand)));
             }
             else {
-                shellCommands.add(String.format("docker-compose -f %s -p %s run -T %s",fileName,projectName,dockerComposeContainerName));
+                shellCommands.add(String.format("docker-compose -f %s -p %s run --rm -T %s",fileName,projectName,dockerComposeContainerName));
             }
         }
         extractWorkingDirIntoWorkSpace(dockerComposeContainerName, projectName, shellCommands);


### PR DESCRIPTION
aka https://docs.docker.com/reference/run/#clean-up-rm => https://docs.docker.com/compose/reference/run/

## Clean up (–rm)

By default a container’s file system persists even after the container exits. This makes debugging a lot easier (since you can inspect the final state) and you retain all your data by default. But if you are running short-term foreground processes, these container file systems can really pile up. If instead you’d like Docker to automatically clean up the container and remove the file system when the container exits, you can add the --rm flag:

```--rm=false: Automatically remove the container when it exits (incompatible with -d)```