### PR TITLE
Use global /tmp instead of writing into workspace

### DIFF
--- a/src/main/resources/com/groupon/jenkins/buildtype/install_packages/template/Node/.ci.yml
+++ b/src/main/resources/com/groupon/jenkins/buildtype/install_packages/template/Node/.ci.yml
@@ -26,7 +26,7 @@ environment:
   language: node
   language_versions: v0.8.25
   vars:
-    TMPDIR: '\${WORKSPACE}/tmp'
+    TMPDIR: '/tmp/\${JOB_NAME}/\${BUILD_NUMBER}'
 
 build:
   before:


### PR DESCRIPTION
Cleanly separates a repository-level tmp/ directory from the global tmp directory used by npm. This fixes a regression where previous assumptions about the post-test state of the checkout (e.g. checks for a clean `git status`) started failing.