### PR TITLE
Fixing a bug where 'Enable private repository support' is not checked

### DIFF
--- a/src/main/resources/com/groupon/jenkins/SetupConfig/config.jelly
+++ b/src/main/resources/com/groupon/jenkins/SetupConfig/config.jelly
@@ -71,7 +71,7 @@ THE SOFTWARE.
                    </f:entry>
 
                    <f:entry title="Enable private repository support">
-                      <f:checkbox name="dotci.privateRepoSupport" value="${instance.privateRepoSupport}"/>
+                      <f:checkbox name="dotci.privateRepoSupport" checked="${instance.privateRepoSupport}"/>
                    </f:entry>
 
                     <f:entry title="Github callback url">


### PR DESCRIPTION
If you check the 'Enable private repository support' to be true, save, and reload the configure page, the checkbox is not auto filled from saved config. If someone hits save again, they will overwrite the true value with false.