### PR TITLE
fix trap to kill and remove docker-compose run SERVICE

### DIFF
--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -80,10 +80,10 @@ public class BuildConfiguration {
             Map runConfig = (Map) config.get("run");
             Object dockerComposeCommand = runConfig.get(dockerComposeContainerName);
             if (dockerComposeCommand != null ) {
-                shellCommands.add(String.format("docker-compose -f %s -p %s run -T %s sh -xc '%s'", fileName, projectName, dockerComposeContainerName,SHELL_ESCAPE.escape((String) dockerComposeCommand)));
+                shellCommands.add(String.format("docker-compose -f %s -p %s run --rm -T %s sh -xc '%s'", fileName, projectName, dockerComposeContainerName,SHELL_ESCAPE.escape((String) dockerComposeCommand)));
             }
             else {
-                shellCommands.add(String.format("docker-compose -f %s -p %s run -T %s",fileName,projectName,dockerComposeContainerName));
+                shellCommands.add(String.format("docker-compose -f %s -p %s run --rm -T %s",fileName,projectName,dockerComposeContainerName));
             }
         }
         extractWorkingDirIntoWorkSpace(dockerComposeContainerName, projectName, shellCommands);

--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -74,16 +74,16 @@ public class BuildConfiguration {
             shellCommands.add(String.format("sh -xc '%s'", SHELL_ESCAPE.escape((String)config.get("before"))));
         }
 
-        shellCommands.add(String.format("trap \"docker-compose -f %s -p %s kill; docker-compose -f %s -p %s rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",fileName,projectName,fileName,projectName));
+        shellCommands.add(String.format("trap \"docker-compose -f %s -p %s kill; docker-compose -f %s -p %s ps -q | xargs docker rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",fileName,projectName,fileName,projectName));
         shellCommands.add(String.format("docker-compose -f %s -p %s pull",fileName,projectName));
         if (config.get("run") != null) {
             Map runConfig = (Map) config.get("run");
             Object dockerComposeCommand = runConfig.get(dockerComposeContainerName);
             if (dockerComposeCommand != null ) {
-                shellCommands.add(String.format("docker-compose -f %s -p %s run --rm -T %s sh -xc '%s'", fileName, projectName, dockerComposeContainerName,SHELL_ESCAPE.escape((String) dockerComposeCommand)));
+                shellCommands.add(String.format("docker-compose -f %s -p %s run -T %s sh -xc '%s'", fileName, projectName, dockerComposeContainerName,SHELL_ESCAPE.escape((String) dockerComposeCommand)));
             }
             else {
-                shellCommands.add(String.format("docker-compose -f %s -p %s run --rm -T %s",fileName,projectName,dockerComposeContainerName));
+                shellCommands.add(String.format("docker-compose -f %s -p %s run -T %s",fileName,projectName,dockerComposeContainerName));
             }
         }
         extractWorkingDirIntoWorkSpace(dockerComposeContainerName, projectName, shellCommands);

--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -74,7 +74,7 @@ public class BuildConfiguration {
             shellCommands.add(String.format("sh -xc '%s'", SHELL_ESCAPE.escape((String)config.get("before"))));
         }
 
-        shellCommands.add(String.format("trap \"docker-compose -f %s -p %s kill; docker-compose -f %s -p %s ps -q | xargs docker rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",fileName,projectName,fileName,projectName));
+        shellCommands.add(String.format("trap \"docker-compose -f %s -p %s kill; docker ps --filter 'name=%s_' -q | xargs docker rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",fileName,projectName,projectName));
         shellCommands.add(String.format("docker-compose -f %s -p %s pull",fileName,projectName));
         if (config.get("run") != null) {
             Map runConfig = (Map) config.get("run");


### PR DESCRIPTION
``docker-compose [stop | kill | rm]`` works only on ``docker-compose up`` and does not appear to effect ``docker-compose run <SERVICE>``

This fix is to workaround docker-compose where 
it will cleanup __cibackbeatbackbeatserver274_ci_1__  
but not __cibackbeatbackbeatserver274_ci_run_1__
```
$ docker-compose -f docker-compose.yml -p cibackbeatbackbeatserver274 run -T ci
Creating cibackbeatbackbeatserver274_redis_1...
Creating cibackbeatbackbeatserver274_database_1...

$ docker-compose -f docker-compose.yml -p cibackbeatbackbeatserver274 ps
                 Name                               Command               State    Ports
------------------------------------------------------------------------------------------
cibackbeatbackbeatserver274_ci_run_1     bin/run-tests.sh                 Up
cibackbeatbackbeatserver274_database_1   /docker-entrypoint.sh postgres   Up      5432/tcp
cibackbeatbackbeatserver274_redis_1      /entrypoint.sh redis-server      Up      6379/tcp

$ for i in `docker-compose -f docker-compose.yml -p cibackbeatbackbeatserver274 ps -q`; do docker kill $i; docker rm -v --force $i; done
8b89782953308e83072e081e87bc4c6ae74d7077c1126cf2e443f85d2839f2b7
8b89782953308e83072e081e87bc4c6ae74d7077c1126cf2e443f85d2839f2b7
9b481e94c17218dd0d8bb16a74374800f859254bfefaf1bd3b02cc46e7ee892a
9b481e94c17218dd0d8bb16a74374800f859254bfefaf1bd3b02cc46e7ee892a
e0ef37d3c87e4979e5e312c835a6fc766150dfbd50c2cf29ff6f8fdd29d9eb83
e0ef37d3c87e4979e5e312c835a6fc766150dfbd50c2cf29ff6f8fdd29d9eb83

$ docker-compose -f docker-compose.yml -p cibackbeatbackbeatserver274 ps
Name   Command   State   Ports
------------------------------
```