### PR TITLE
Docker compose before action

### DIFF
--- a/docs/usage/ci_yml/build_types/DockerCompose.md
+++ b/docs/usage/ci_yml/build_types/DockerCompose.md
@@ -5,6 +5,13 @@ dependencies. The author should assume that only that tool is available.
 
 ## `.ci.yml` Sections
 
+### `before`
+
+```
+before: "./some_script && ./another_script"
+```
+Specify any commands that should be run before building the image.
+
 ### `run`
 
 ```

--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -72,6 +72,10 @@ public class BuildConfiguration {
         String fileName = getDockerComposeFileName();
         ShellCommands shellCommands = new ShellCommands();
         shellCommands.add(checkoutCommands);
+        if (config.get("before") != null) {
+            shellCommands.add(String.format("sh -xc '%s'", SHELL_ESCAPE.escape((String)config.get("before"))));
+        }
+
         shellCommands.add(String.format("trap \"docker-compose -f %s -p %s kill; docker-compose -f %s -p %s rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",fileName,projectName,fileName,projectName));
         shellCommands.add(String.format("docker-compose -f %s -p %s pull",fileName,projectName));
         if (config.get("run") != null) {

--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -72,7 +72,7 @@ public class BuildConfiguration {
         String fileName = getDockerComposeFileName();
         ShellCommands shellCommands = new ShellCommands();
         shellCommands.add(checkoutCommands);
-        if (config.get("before") != null) {
+        if (config.containsKey("before")) {
             shellCommands.add(String.format("sh -xc '%s'", SHELL_ESCAPE.escape((String)config.get("before"))));
         }
 

--- a/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
+++ b/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
@@ -62,11 +62,21 @@ public class BuildConfigurationTest {
     Assert.assertEquals("docker-compose -f docker-compose.yml -p unitgroupondotci8 run -T unit sh -xc 'command'",commands.get(2));
   }
 
+  @Test
+  public void should_run_before_command_if_present(){
+    ShellCommands commands = getRunCommandsWithBefore();
+    Assert.assertEquals("sh -xc 'before cmd'", commands.get(0));
+    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml -p unitgroupondotci8 kill; docker-compose -f docker-compose.yml -p unitgroupondotci8 rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(1));
+  }
 
   private ShellCommands getRunCommands() {
     BuildConfiguration buildConfiguration = new BuildConfiguration("groupon/DotCi", ImmutableMap.of("run", of("unit", "command", "integration", "integration")), "buildId", new ShellCommands(), "abc123", 8);
     return buildConfiguration.getCommands(Combination.fromString("script=unit"));
   }
 
-
+  private ShellCommands getRunCommandsWithBefore() {
+    Map ci_config = ImmutableMap.of("before", "before cmd", "run", of("unit", "command", "integration", "integration"));
+    BuildConfiguration buildConfiguration = new BuildConfiguration("groupon/DotCi", ci_config, "buildId", new ShellCommands(), "abc123", 8);
+    return buildConfiguration.getCommands(Combination.fromString("script=unit"));
+  }
 }


### PR DESCRIPTION
Commands are read from the repo's .ci.yml file and expected to live in a
section called "before".  Only one before command is permitted, multiple
commands can be chained via '&&'.

Example:
before: git submodule update --init --recursive && ./s_build_prep
run:
  api: ./s_test