### PR TITLE
Remove git suffix from default clone url template

### DIFF
--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/GlobalConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/GlobalConfiguration.java
@@ -11,7 +11,7 @@ public class GlobalConfiguration extends jenkins.model.GlobalConfiguration {
     public static GlobalConfiguration get() {
         return jenkins.model.GlobalConfiguration.all().get(GlobalConfiguration.class);
     }
-    public static final String DEFAULT_CLONE_URL_TEMPlATE = "https://<DOMAIN>/<ORG>/<REPO>.git";
+    public static final String DEFAULT_CLONE_URL_TEMPlATE = "https://<DOMAIN>/<ORG>/<REPO>";
 
 
     public String getCloneUrlTemplate() {


### PR DESCRIPTION
After updating the plugin, the git remote url included two ".git" suffixes.
```bash
$  git init
Initialized empty Git repository in /home/core/workspace/aheuermann/test@2/script=node/.git/
$  git remote add origin git@github.com:aheuermann/test.git.git
```