### PR TITLE
We don't need to hardcode 'sh -xc'; removing this makes us agnostic t…

### DIFF
--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -71,7 +71,7 @@ public class BuildConfiguration {
             Map runConfig = (Map) config.get("run");
             Object dockerComposeCommand = runConfig.get(dockerComposeContainerName);
             if (dockerComposeCommand != null ) {
-                shellCommands.add(String.format("docker-compose -f %s -p %s run -T %s sh -xc '%s'", fileName, projectName, dockerComposeContainerName,SHELL_ESCAPE.escape((String) dockerComposeCommand)));
+                shellCommands.add(String.format("docker-compose -f %s -p %s run -T %s %s", fileName, projectName, dockerComposeContainerName,SHELL_ESCAPE.escape((String) dockerComposeCommand)));
             }
             else {
                 shellCommands.add(String.format("docker-compose -f %s -p %s run -T %s",fileName,projectName,dockerComposeContainerName));

--- a/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
+++ b/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
@@ -59,7 +59,7 @@ public class BuildConfigurationTest {
   @Test
   public  void should_run_cmd_from_ci_yml(){
     ShellCommands commands = getRunCommands();
-    Assert.assertEquals("docker-compose -f docker-compose.yml -p unitgroupondotci8 run -T unit sh -xc 'command'",commands.get(8));
+    Assert.assertEquals("docker-compose -f docker-compose.yml -p unitgroupondotci8 run -T unit command",commands.get(8));
   }
 
   @Test
@@ -76,7 +76,7 @@ public class BuildConfigurationTest {
     ShellCommands commands = buildConfiguration.getCommands(Combination.fromString("script=unit"), getEnvVars());
     Assert.assertEquals("trap \"docker-compose -f ./jenkins/docker-compose.yml -p unitgroupondotci8 kill; docker-compose -f ./jenkins/docker-compose.yml -p unitgroupondotci8 rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(6));
     Assert.assertEquals("docker-compose -f ./jenkins/docker-compose.yml -p unitgroupondotci8 pull",commands.get(7));
-    Assert.assertEquals("docker-compose -f ./jenkins/docker-compose.yml -p unitgroupondotci8 run -T unit sh -xc 'command'",commands.get(8));
+    Assert.assertEquals("docker-compose -f ./jenkins/docker-compose.yml -p unitgroupondotci8 run -T unit command",commands.get(8));
   }
 
   private ShellCommands getRunCommands() {


### PR DESCRIPTION
…o whether or not the image is an entrypoint image or not.