### PR TITLE
Adding before_run command

### DIFF
--- a/docs/user-guide/DockerCompose.md
+++ b/docs/user-guide/DockerCompose.md
@@ -9,13 +9,20 @@ docker-compose-file: "./jenkins/docker-compose.yml"
 ```
 Specify an alternate compose file (default: docker-compose.yml)
 
-### `before`
-
+### `before_run`
 
 ```yaml
-before: "./some_script && ./another_script"
+before_run: "./some_script && ./another_script"
 ```
-Specify any commands that should be run before building the image.
+Specify commands that should be run before the run commands. These commands will execute once. 
+
+
+### `before_each`
+
+```yaml
+before_each: "./some_script && ./another_script"
+```
+Specify commands that should be run before each run sub-command. 
 
 ### `run`
 

--- a/src/main/java/com/groupon/jenkins/buildtype/util/shell/ShellCommands.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/util/shell/ShellCommands.java
@@ -116,7 +116,7 @@ public class ShellCommands {
         return this;
     }
 
-    private Collection<? extends String> getCommands() {
+    public Collection<? extends String> getCommands() {
         return commands;
     }
 

--- a/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
+++ b/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
@@ -27,7 +27,6 @@ package com.groupon.jenkins.buildtype.dockercompose;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.groupon.jenkins.buildtype.util.shell.ShellCommands;
-import hudson.matrix.AxisList;
 import hudson.matrix.Combination;
 import org.junit.Assert;
 import static  com.google.common.collect.ImmutableMap.of;
@@ -44,17 +43,18 @@ public class BuildConfigurationTest {
     Assert.assertEquals("script=unit", Iterables.get(axisList,0).toString());
     Assert.assertEquals("script=integration", Iterables.get(axisList,1).toString());
   }
+
   @Test
   public  void should_cleanup_after_test_run(){
     ShellCommands commands = getRunCommands();
     Assert.assertEquals("trap \"docker-compose -f docker-compose.yml -p unitgroupondotci8 kill; docker-compose -f docker-compose.yml -p unitgroupondotci8 rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(6));
   }
+
   @Test
   public  void should_pull_latest_image_from_registry(){
     ShellCommands commands = getRunCommands();
     Assert.assertEquals("docker-compose -f docker-compose.yml -p unitgroupondotci8 pull",commands.get(7));
   }
-
 
   @Test
   public  void should_run_cmd_from_ci_yml(){
@@ -63,20 +63,51 @@ public class BuildConfigurationTest {
   }
 
   @Test
-  public void should_run_before_command_if_present(){
-    ShellCommands commands = getRunCommandsWithBefore();
-    Assert.assertEquals("sh -xc 'before cmd'", commands.get(6));
+  public void should_run_before_each_command_if_present(){
+    ShellCommands commands = getRunCommands(ImmutableMap.of("before_each", "before_each cmd", "run", of("unit", "command", "integration", "integration")));
+    Assert.assertEquals("sh -xc 'before_each cmd'", commands.get(6));
     Assert.assertEquals("trap \"docker-compose -f docker-compose.yml -p unitgroupondotci8 kill; docker-compose -f docker-compose.yml -p unitgroupondotci8 rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(7));
   }
 
   @Test
-  public void should_accept_alternative_docker_compose_file(){
-    Map ci_config = ImmutableMap.of("docker-compose-file", "./jenkins/docker-compose.yml", "run",  of("unit", "command"));
-    BuildConfiguration buildConfiguration = new BuildConfiguration("groupon/DotCi", ci_config,  8);
+  public void should_run_before_run_command_in_before_run_if_present(){
+    BuildConfiguration buildConfiguration = new BuildConfiguration("groupon/DotCi", ImmutableMap.of("before_run", "before_run cmd", "run", of("unit", "command")),  8);
     ShellCommands commands = buildConfiguration.getCommands(Combination.fromString("script=unit"), getEnvVars());
+    Assert.assertEquals("sh -xc 'before_run cmd'", commands.get(6));
+  }
+
+  @Test
+  public void should_run_before_run_with_checkout_command_with_non_parallel_build(){
+    BuildConfiguration buildConfiguration = new BuildConfiguration("groupon/DotCi", ImmutableMap.of("before_run", "before_run cmd", "run", of("unit", "command", "integration", "integration")),  8);
+    ShellCommands commands = buildConfiguration.getBeforeRunCommandWithCheckoutIfPresent(getEnvVars());
+    Assert.assertEquals("chmod -R u+w . ; find . ! -path \"./deploykey_rsa.pub\" ! -path \"./deploykey_rsa\" -delete", commands.get(0));
+    Assert.assertEquals("git init", commands.get(1));
+    Assert.assertEquals("git remote add origin git@github.com:groupon/DotCi.git", commands.get(2));
+    Assert.assertEquals("git fetch origin master", commands.get(3));
+    Assert.assertEquals("git reset --hard  abc123", commands.get(4));
+    Assert.assertEquals("sh -xc 'before_run cmd'", commands.get(6));
+  }
+
+  @Test
+  public void should_not_run_before_run_for_parallel_subbuild(){
+    BuildConfiguration buildConfiguration = new BuildConfiguration("groupon/DotCi", ImmutableMap.of("before_run", "before_run cmd", "run", of("unit", "command", "integration", "integration")),  8);
+    ShellCommands commands = buildConfiguration.getCommands(Combination.fromString("script=unit"), getEnvVars());
+    for (String command : commands.getCommands()) {
+      Assert.assertNotEquals("before_run cmd", command);
+    }
+  }
+
+  @Test
+  public void should_accept_alternative_docker_compose_file(){
+    ShellCommands commands = getRunCommands(ImmutableMap.of("docker-compose-file", "./jenkins/docker-compose.yml", "run",  of("unit", "command")));
     Assert.assertEquals("trap \"docker-compose -f ./jenkins/docker-compose.yml -p unitgroupondotci8 kill; docker-compose -f ./jenkins/docker-compose.yml -p unitgroupondotci8 rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(6));
     Assert.assertEquals("docker-compose -f ./jenkins/docker-compose.yml -p unitgroupondotci8 pull",commands.get(7));
     Assert.assertEquals("docker-compose -f ./jenkins/docker-compose.yml -p unitgroupondotci8 run -T unit command",commands.get(8));
+  }
+
+  private ShellCommands getRunCommands(Map ciConfig) {
+    BuildConfiguration buildConfiguration = new BuildConfiguration("groupon/DotCi", ciConfig, 8);
+    return buildConfiguration.getCommands(Combination.fromString("script=unit"), getEnvVars());
   }
 
   private ShellCommands getRunCommands() {
@@ -84,13 +115,7 @@ public class BuildConfigurationTest {
     return buildConfiguration.getCommands(Combination.fromString("script=unit"), getEnvVars());
   }
 
-  private ShellCommands getRunCommandsWithBefore() {
-    Map ci_config = ImmutableMap.of("before", "before cmd", "run", of("unit", "command", "integration", "integration"));
-    BuildConfiguration buildConfiguration = new BuildConfiguration("groupon/DotCi", ci_config,  8);
-    return buildConfiguration.getCommands(Combination.fromString("script=unit"), getEnvVars());
-  }
-
   private Map<String, Object> getEnvVars() {
-    return ImmutableMap.<String,Object>of("DOTCI_DOCKER_COMPOSE_GIT_CLONE_URL","git@github.com:groupon/DotCi.git");
+    return ImmutableMap.<String,Object>of("DOTCI_DOCKER_COMPOSE_GIT_CLONE_URL","git@github.com:groupon/DotCi.git", "DOTCI_BRANCH", "master", "SHA", "abc123");
   }
 }


### PR DESCRIPTION
Fixes #180 

This PR adds a `before_run` command which runs before the `run` scripts and once per main build. I wasn't sure how to implement the flyweight pattern in Jenkins you discussed, so this runs on the "conductor". Since the conductor currently takes up an executor, I assume this is not a big deal, but let me know if you prefer that it be done differently.

I also renamed the `before` to `before_each` but still support `before` so current builds will not break after upgrade.

Let me know what you think.
