### PR TITLE
Queued build overshadowing latest non-queued build

### DIFF
--- a/src/main/java/com/groupon/jenkins/dynamic/build/repository/DynamicProjectRepository.java
+++ b/src/main/java/com/groupon/jenkins/dynamic/build/repository/DynamicProjectRepository.java
@@ -202,6 +202,6 @@ public class DynamicProjectRepository extends MongoRepository {
             return 1;
         }
 
-        return seq.getCounter();
+        return seq.getCounter() + 1;
     }
 }

--- a/src/main/jsx/colors.css
+++ b/src/main/jsx/colors.css
@@ -3,6 +3,7 @@
   --failure:   #c00;
   --aborted:   #666;
   --in_progress:   #E7D100;
+  --queued: #A6ADAD;
 
   --paper-teal-50: #e0f2f1;
   --paper-teal-100: #b2dfdb;

--- a/src/main/jsx/components/job/BuildRow.jsx
+++ b/src/main/jsx/components/job/BuildRow.jsx
@@ -51,18 +51,18 @@ export default React.createClass({
         <div className ={"build-info build-info-"+result}>
           {this._statusRow(result,cause)}
           <span>
-            <div className="build-row--title"><small>{branch}</small> 
-              <PageLink  href={this._buildUrl()}>{message}</PageLink>
-            </div> 
+            <div className="build-row--title"><small>{branch}</small>
+              <PageLink disabled={this._isDisabled()} href={this._buildUrl()}>{message}</PageLink>
+            </div>
             <div className="build-row--committer">
               <Avatar avatarUrl={avatarUrl} />
               <span>{committerName}</span>
             </div>
             <div className="build-row--cause">{cause['shortDescription']}</div>
           </span>
-          <span>  
-            <div>#<PageLink  className="build-row--number" href={this._buildUrl()}>{number}{result.toLowerCase()}</PageLink></div>
-            <div><iron-icon icon="github:octoface"/><a className="github-link link-no-decoration" href={commitUrl}> {shortSha}</a></div>
+          <span>
+            <div>#<PageLink className="build-row--number" href={this._buildUrl()} disabled={this._isDisabled()}>{number}{result.toLowerCase()}</PageLink></div>
+            {this._sha(commitUrl, shortSha)}
           </span>
           <span>
             <div>
@@ -83,6 +83,16 @@ export default React.createClass({
       <BuildIcon result={result} />
       <BuildCauseIcon cause={cause['name']} />
     </span>
+  },
+  _isDisabled() {
+    return this.props.build.result === "QUEUED";
+  },
+  _sha(commitUrl, shortSha) {
+    let child = <a className="github-link link-no-decoration" href={commitUrl}><iron-icon icon="github:octoface"/>{shortSha}</a>
+    if (this._isDisabled()) {
+      child = <span className="github-link link-no-decoration" href={commitUrl}><iron-icon icon="github:octoface"/>{shortSha}</span>
+    }
+    return <div>{child}</div>
   },
   _buildUrl(){
     return this.props.fullUrl? this.props.build.url: "/"+this.props.build.number;

--- a/src/main/jsx/components/job/build_row.css
+++ b/src/main/jsx/components/job/build_row.css
@@ -38,6 +38,14 @@
     transition: background-color 1s ease-in;
     padding-top: 1em;
   }
+  &-QUEUED{
+    >:nth-child(1){
+      background-color: var(--queued);
+    }
+    .build-row--number{
+      color: var(--queued);
+    }
+  }
   &-FAILURE{
     >:nth-child(1){
       background-color: var(--failure);

--- a/src/main/jsx/components/job/build_row_small.css
+++ b/src/main/jsx/components/job/build_row_small.css
@@ -3,6 +3,10 @@
   margin-left: 10px;
 }
 
+.build-row-small.QUEUED{
+  color: var(--queued);
+}
+
 .build-row-small.FAILURE{
   color: var(--failure);
 }

--- a/src/main/jsx/components/job/build_step.css
+++ b/src/main/jsx/components/job/build_step.css
@@ -14,6 +14,9 @@
   display: flex;
   align-items: center;
   .compact{
+    &-QUEUED{
+       border: 3px solid var(--queued) !important;
+    }
     &-SUCCESS{
       border: 3px solid var(--success) !important;
     }

--- a/src/main/jsx/components/lib/PageLink.jsx
+++ b/src/main/jsx/components/lib/PageLink.jsx
@@ -2,7 +2,12 @@ import React from 'react';
 import page from 'page';
 export default React.createClass({
   render(){
-    return    <a className={this.props.className} href="#" onClick={this._onClick}>
+    if (this.props.disabled) {
+      return <span className={this.props.className}>
+        {this.props.children}
+      </span>
+    }
+    return <a className={this.props.className} href="#" onClick={this._onClick}>
       {this.props.children}
     </a>
   },


### PR DESCRIPTION
If you have a queued build, the most recent build shows up as queued in the history view.  

Also, I made queued build non-clickable since right now builds are pulled from the db and these are not persisted yet. 