### PR TITLE
Adding after_each command

### DIFF
--- a/docs/user-guide/DockerCompose.md
+++ b/docs/user-guide/DockerCompose.md
@@ -24,6 +24,13 @@ before_each: "./some_script && ./another_script"
 ```
 Specify commands that should be run before each run sub-command. 
 
+### `after_each` (Optional)
+
+```yaml
+after_each: "./some_script && ./another_script"
+```
+Specify commands that should be run after each run sub-command. These will run on success and failure. 
+
 ### `run` (Required)
 
 ```yaml

--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -71,6 +71,7 @@ public class BuildConfiguration {
         ShellCommands shellCommands = new ShellCommands();
         shellCommands.add(BuildConfiguration.getCheckoutCommands(dotCiEnvVars));
 
+        shellCommands.add(String.format("trap \"docker-compose -f %s kill; docker-compose -f %s rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",fileName,fileName));
         if (config.containsKey("before_run") && !isParallelized()) {
             shellCommands.add(String.format("sh -xc '%s'", SHELL_ESCAPE.escape((String) config.get("before_run"))));
         }
@@ -80,7 +81,6 @@ public class BuildConfiguration {
             shellCommands.add(String.format("sh -xc '%s'", SHELL_ESCAPE.escape(beforeScript)));
         }
 
-        shellCommands.add(String.format("trap \"docker-compose -f %s kill; docker-compose -f %s rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",fileName,fileName));
         shellCommands.add(String.format("docker-compose -f %s pull",fileName));
         if (config.get("run") != null) {
             Map runConfig = (Map) config.get("run");

--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -173,8 +173,6 @@ public class BuildConfiguration {
                 shellCommands.add(format("git fetch origin %s",dotCiEnvVars.get("DOTCI_BRANCH")));
             }
             shellCommands.add(format("git reset --hard  %s", dotCiEnvVars.get("SHA")));
-            //TODO Handle dockerfiles with onbuild add directives
-            shellCommands.add("( for dockerfile in $(find . -name '*Dockerfile*'); do dockerfileName=$(basename $dockerfile) ; dockerfilePath=$(dirname $dockerfile); pushd $dockerfilePath >/dev/null ; for filename in $(grep ADD $dockerfileName | sed -e 's/^\\s*ADD\\s*//g' ; grep COPY $dockerfileName | sed -e 's/^\\s*COPY\\s*//g' ); do test -d $filename && continue ; test -f $filename || continue ; sha=$(git rev-list -n 1 HEAD $filename) ; touch -d \"$(git show -s --format=%ai $sha)\" $filename ; popd >/dev/null ; done ; done ) || true # Set modified time of files added in Dockerfiles to allow for build caching");
         }
         return shellCommands;
     }

--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -63,7 +63,7 @@ public class BuildConfiguration {
         return shellCommands;
     }
 
-    public ShellCommands getCommands(Combination combination, Map<String, Object> dotCiEnvVars) {
+    public List<ShellCommands> getCommands(Combination combination, Map<String, Object> dotCiEnvVars) {
         String dockerComposeContainerName = combination.get("script");
         String projectName = (String) dotCiEnvVars.get("COMPOSE_PROJECT_NAME");
         String fileName = getDockerComposeFileName();
@@ -94,7 +94,12 @@ public class BuildConfiguration {
         }
         extractWorkingDirIntoWorkSpace(dockerComposeContainerName, projectName, shellCommands);
 
-        return shellCommands;
+        List<ShellCommands> commandList = new ArrayList<ShellCommands>();
+        commandList.add(shellCommands);
+        if (config.containsKey("after_each")) {
+            commandList.add(new ShellCommands(String.format("sh -xc '%s'", SHELL_ESCAPE.escape((String) config.get("after_each")))));
+        }
+        return commandList;
     }
 
     private void extractWorkingDirIntoWorkSpace(String dockerComposeContainerName, String projectName, ShellCommands shellCommands) {
@@ -102,7 +107,6 @@ public class BuildConfiguration {
             shellCommands.add(getCopyWorkDirIntoWorkspaceCommands(dockerComposeContainerName, projectName));
         }
     }
-
 
     public AxisList getAxisList() {
         String dockerComposeContainerName = getOnlyRun();

--- a/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
+++ b/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
@@ -65,15 +65,15 @@ public class BuildConfigurationTest {
   @Test
   public void should_run_before_each_command_if_present(){
     ShellCommands commands = getRunCommands(ImmutableMap.of("before_each", "before_each cmd", "run", of("unit", "command", "integration", "integration")));
-    Assert.assertEquals("sh -xc 'before_each cmd'", commands.get(5));
-    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(6));
+    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(5));
+    Assert.assertEquals("sh -xc 'before_each cmd'", commands.get(6));
   }
 
   @Test
   public void should_run_before_run_command_in_before_run_if_present(){
     BuildConfiguration buildConfiguration = new BuildConfiguration(ImmutableMap.of("before_run", "before_run cmd", "run", of("unit", "command")));
     List<ShellCommands> commands = buildConfiguration.getCommands(Combination.fromString("script=unit"), getEnvVars());
-    Assert.assertEquals("sh -xc 'before_run cmd'", commands.get(0).get(5));
+    Assert.assertEquals("sh -xc 'before_run cmd'", commands.get(0).get(6));
   }
 
   @Test

--- a/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
+++ b/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
@@ -47,33 +47,33 @@ public class BuildConfigurationTest {
   @Test
   public  void should_cleanup_after_test_run(){
     ShellCommands commands = getRunCommands();
-    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(6));
+    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(5));
   }
 
   @Test
   public  void should_pull_latest_image_from_registry(){
     ShellCommands commands = getRunCommands();
-    Assert.assertEquals("docker-compose -f docker-compose.yml pull",commands.get(7));
+    Assert.assertEquals("docker-compose -f docker-compose.yml pull",commands.get(6));
   }
 
   @Test
   public  void should_run_cmd_from_ci_yml(){
     ShellCommands commands = getRunCommands();
-    Assert.assertEquals("docker-compose -f docker-compose.yml run -T unit command",commands.get(8));
+    Assert.assertEquals("docker-compose -f docker-compose.yml run -T unit command",commands.get(7));
   }
 
   @Test
   public void should_run_before_each_command_if_present(){
     ShellCommands commands = getRunCommands(ImmutableMap.of("before_each", "before_each cmd", "run", of("unit", "command", "integration", "integration")));
-    Assert.assertEquals("sh -xc 'before_each cmd'", commands.get(6));
-    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(7));
+    Assert.assertEquals("sh -xc 'before_each cmd'", commands.get(5));
+    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(6));
   }
 
   @Test
   public void should_run_before_run_command_in_before_run_if_present(){
     BuildConfiguration buildConfiguration = new BuildConfiguration(ImmutableMap.of("before_run", "before_run cmd", "run", of("unit", "command")));
     ShellCommands commands = buildConfiguration.getCommands(Combination.fromString("script=unit"), getEnvVars());
-    Assert.assertEquals("sh -xc 'before_run cmd'", commands.get(6));
+    Assert.assertEquals("sh -xc 'before_run cmd'", commands.get(5));
   }
 
   @Test
@@ -95,9 +95,9 @@ public class BuildConfigurationTest {
   @Test
   public void should_accept_alternative_docker_compose_file(){
     ShellCommands commands = getRunCommands(ImmutableMap.of("docker-compose-file", "./jenkins/docker-compose.yml", "run",  of("unit", "command")));
-    Assert.assertEquals("trap \"docker-compose -f ./jenkins/docker-compose.yml kill; docker-compose -f ./jenkins/docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(6));
-    Assert.assertEquals("docker-compose -f ./jenkins/docker-compose.yml pull",commands.get(7));
-    Assert.assertEquals("docker-compose -f ./jenkins/docker-compose.yml run -T unit command",commands.get(8));
+    Assert.assertEquals("trap \"docker-compose -f ./jenkins/docker-compose.yml kill; docker-compose -f ./jenkins/docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(5));
+    Assert.assertEquals("docker-compose -f ./jenkins/docker-compose.yml pull",commands.get(6));
+    Assert.assertEquals("docker-compose -f ./jenkins/docker-compose.yml run -T unit command",commands.get(7));
   }
   @Test
   public void should_be_skipped_if_skip_specified(){


### PR DESCRIPTION
#### Summary of changes:

1. Removed the command that sets the modified time of files in `ADD` and `COPY`. Docker 1.8 [no longer uses modified time when determining cache](https://github.com/docker/docker/pull/12031).
2. Added an `after_each` that runs regardless of pass or fail of the run.
3. Moved the current trap to run `before_each` for sub builds (just in case compose commands are run there and it fails)

Let me know what you think. Thanks!