### PR TITLE
upgrade to org.apache.httpcomponents:httpclient:4.5.1 for CookieSpecProvider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.1</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>


### PR DESCRIPTION
Upgrade because I've confirmed that [httpclient-4.1](http://search.maven.org/remotecontent?filepath=org/apache/httpcomponents/httpclient/4.1/httpclient-4.1-sources.jar) will cause https://github.com/groupon/DotCi-Plugins-Starter-Pack/issues/9
```
Caused by: java.lang.ClassNotFoundException: org.apache.http.cookie.CookieSpecProvider
```

Therefore you want [httpclient-4.5.1](http://search.maven.org/remotecontent?filepath=org/apache/httpcomponents/httpclient/4.5.1/httpclient-4.5.1-sources.jar) for https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/cookie/CookieSpecProvider.html

now available as-of https://github.com/apache/httpclient/commit/8901aed4949de2d597e09f645dfb2a0507839483 in 4.3+