### PR TITLE
Allow specifying the sub build label in .ci.yml

### DIFF
--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -128,6 +128,10 @@ public class BuildConfiguration {
         return (String) runConfig.keySet().iterator().next();
     }
 
+    public String getSubBuildLabel() {
+        return (String) config.get("sub_build_label");
+    }
+
     public boolean isParallelized() {
         return ((Map) config.get("run")).size() > 1 ;
     }

--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/DockerComposeBuild.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/DockerComposeBuild.java
@@ -45,7 +45,6 @@ import hudson.model.BuildListener;
 import hudson.model.Result;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -112,7 +111,6 @@ public class DockerComposeBuild extends BuildType implements SubBuildRunner {
     }
 
     private Result runParallelBuild(final DynamicBuild dynamicBuild, final  BuildExecutionContext buildExecutionContext, final BuildConfiguration buildConfiguration, final BuildListener listener) throws IOException, InterruptedException {
-
         SubBuildScheduler subBuildScheduler = new SubBuildScheduler(dynamicBuild, this, new SubBuildScheduler.SubBuildFinishListener() {
             @Override
             public void runFinished(DynamicSubBuild subBuild) throws IOException {
@@ -124,7 +122,8 @@ public class DockerComposeBuild extends BuildType implements SubBuildRunner {
 
         try {
             Iterable<Combination> axisList = buildConfiguration.getAxisList().list();
-            Result runResult = subBuildScheduler.runSubBuilds(axisList, listener);
+            String subBuild =  buildConfiguration.getSubBuildLabel();
+            Result runResult = subBuildScheduler.runSubBuilds(axisList, listener, subBuild);
             if(runResult.equals(Result.SUCCESS)){
                 Result afterRunResult = runAfterCommands(buildExecutionContext,listener);
                 runResult = runResult.combine(afterRunResult);

--- a/src/main/java/com/groupon/jenkins/dynamic/build/execution/NodeAssignmentAction.java
+++ b/src/main/java/com/groupon/jenkins/dynamic/build/execution/NodeAssignmentAction.java
@@ -1,0 +1,52 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014, Groupon, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+ */
+package com.groupon.jenkins.dynamic.build.execution;
+
+import hudson.model.InvisibleAction;
+import hudson.model.Label;
+import hudson.model.labels.LabelAssignmentAction;
+import hudson.model.queue.SubTask;
+import org.mongodb.morphia.annotations.Transient;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Created by a on 12/28/15.
+ */
+public class NodeAssignmentAction extends InvisibleAction implements LabelAssignmentAction {
+
+    @Transient
+    private Label label;
+
+    public NodeAssignmentAction(Label label) {
+        super();
+        this.label = label;
+    }
+
+
+    @Override
+    public Label getAssignedLabel(@Nonnull SubTask subTask) {
+        return label;
+    }
+}


### PR DESCRIPTION
Adding `sub_build_label` property to `.ci.yml`.  If specified, it will override the master's label for the scheduled sub builds.

It can be a string.
```yml
sub_build_label: dotci
```
You can also use env variables such as `NODE_NAME` since it passes through the groovy template.

```yml
sub_build_label: "$NODE_NAME"
```
[It should work for expressions too](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/model/Jenkins.java#L1620) although I haven't tried them.

Let me know if you are on-board with this change and I can add docs.

Fixes #210 