### PR TITLE
Adding support for specifying list of commands in before/after commands

### DIFF
--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -199,22 +199,18 @@ public class BuildConfiguration {
 
         ShellCommands commands = new ShellCommands();
         if (value instanceof String) {
-            commands.add(escapeShellCommand((String) value));
+            commands.add((String) value);
         } else if (value instanceof List) {
             List l = (List) value;
 
             for (Object v : l) {
                 if (!(v instanceof String)) {
-                    throw new RuntimeException("Unexpected type. Expected String");
+                    throw new RuntimeException(String.format("Unexpected type: %s. Expected String for key: %s", v.getClass().getName(), key));
                 }
-                commands.add(escapeShellCommand((String) v));
+                commands.add((String) v);
             }
         }
         return commands;
-    }
-
-    private String escapeShellCommand(String command) {
-        return SHELL_ESCAPE.escape(command);
     }
 
     public boolean isSkipped() {

--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -57,11 +57,12 @@ public class BuildConfiguration {
         this.config = config;
     }
 
-    public String getBeforeRunCommandIfPresent() {
-        return config.containsKey("before_run")?  SHELL_ESCAPE.escape((String) config.get("before_run")):null;
+    public ShellCommands getBeforeRunCommandsIfPresent() {
+        return getShellCommands("before_run");
     }
-    public String getAfterRunCommandIfPresent() {
-        return config.containsKey("after_run")?  SHELL_ESCAPE.escape((String) config.get("after_run")):null;
+
+    public ShellCommands getAfterRunCommandsIfPresent() {
+        return getShellCommands("after_run");
     }
 
     public ShellCommands getCommands(Combination combination, Map<String, Object> dotCiEnvVars) {
@@ -74,8 +75,8 @@ public class BuildConfiguration {
 
         shellCommands.add(String.format("trap \"docker-compose -f %s kill; docker-compose -f %s rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",fileName,fileName));
         if (config.containsKey("before_each") || config.containsKey("before")) {
-            String beforeCommand = (String) (config.containsKey("before_each") ? config.get("before_each") : config.get("before"));
-            shellCommands.add( SHELL_ESCAPE.escape(beforeCommand));
+            String key = (config.containsKey("before_each") ? "before_each" : "before");
+            appendCommands(key, shellCommands);
         }
 
         shellCommands.add(String.format("docker-compose -f %s pull",fileName));
@@ -88,10 +89,10 @@ public class BuildConfiguration {
         extractWorkingDirIntoWorkSpace(dockerComposeContainerName, projectName, shellCommands);
 
         if (config.containsKey("after_each")) {
-            shellCommands.add(SHELL_ESCAPE.escape ((String) config.get("after_each")));
+            appendCommands("after_each", shellCommands);
         }
         if (config.containsKey("after_run") && !isParallelized()) {
-            shellCommands.add(getAfterRunCommandIfPresent());
+            appendCommands("after_each", shellCommands);
         }
         return shellCommands;
     }
@@ -183,6 +184,37 @@ public class BuildConfiguration {
             shellCommands.add(format("git reset --hard  %s", dotCiEnvVars.get("SHA")));
         }
         return shellCommands;
+    }
+
+    private void appendCommands(String key, ShellCommands commands) {
+        ShellCommands added = getShellCommands(key);
+        commands.add(added);
+    }
+
+    private ShellCommands getShellCommands(String key) {
+        Object value = config.get(key);
+        if (value == null) {
+            return null;
+        }
+
+        ShellCommands commands = new ShellCommands();
+        if (value instanceof String) {
+            commands.add(escapeShellCommand((String) value));
+        } else if (value instanceof List) {
+            List l = (List) value;
+
+            for (Object v : l) {
+                if (!(v instanceof String)) {
+                    throw new RuntimeException("Unexpected type. Expected String");
+                }
+                commands.add(escapeShellCommand((String) v));
+            }
+        }
+        return commands;
+    }
+
+    private String escapeShellCommand(String command) {
+        return SHELL_ESCAPE.escape(command);
     }
 
     public boolean isSkipped() {

--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/DockerComposeBuild.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/DockerComposeBuild.java
@@ -98,8 +98,11 @@ public class DockerComposeBuild extends BuildType implements SubBuildRunner {
     }
 
     private Result runCommands(ShellCommands commands, BuildExecutionContext buildExecutionContext, BuildListener listener) throws IOException, InterruptedException {
+        if (commands == null) {
+            return Result.SUCCESS;
+        }
         ShellScriptRunner shellScriptRunner = new ShellScriptRunner(buildExecutionContext, listener);
-            return shellScriptRunner.runScript(commands);
+        return shellScriptRunner.runScript(commands);
     }
 
     private String getDotCiYml(DynamicBuild build) throws IOException, InterruptedException {
@@ -141,19 +144,11 @@ public class DockerComposeBuild extends BuildType implements SubBuildRunner {
     }
 
     private Result runAfterCommands(BuildExecutionContext buildExecutionContext, BuildListener listener) throws IOException, InterruptedException {
-        String afterCommand = buildConfiguration.getAfterRunCommandIfPresent();
-        if (afterCommand != null) {
-            return runCommands(new ShellCommands(afterCommand), buildExecutionContext, listener);
-        }
-        return Result.SUCCESS;
+        return runCommands(buildConfiguration.getAfterRunCommandsIfPresent(), buildExecutionContext, listener);
     }
 
     private Result runBeforeCommands(final BuildExecutionContext buildExecutionContext, final BuildListener listener) throws IOException, InterruptedException {
-        String beforeCommand = buildConfiguration.getBeforeRunCommandIfPresent();
-        if (beforeCommand != null) {
-            return runCommands(new ShellCommands(beforeCommand), buildExecutionContext, listener);
-        }
-        return Result.SUCCESS;
+        return runCommands(buildConfiguration.getBeforeRunCommandsIfPresent(), buildExecutionContext, listener);
     }
 
     private Result runPlugins(DynamicBuild dynamicBuild, List<DotCiPluginAdapter> plugins, BuildListener listener, Launcher launcher) {

--- a/src/main/java/com/groupon/jenkins/buildtype/util/shell/ShellCommands.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/util/shell/ShellCommands.java
@@ -133,4 +133,8 @@ public class ShellCommands {
         }
         return combinedShellCommands;
     }
+
+    public int size() {
+        return commands.size();
+    }
 }


### PR DESCRIPTION
It is backwards compatible, so you can still do this:
```yml 
before_run: 
  - cmd1
  - cmd2
before_each: cmd3
run:
  golang: go test ./...
```