### PR TITLE
Issue #203 adding environment variable for pull request label

### DIFF
--- a/src/main/java/com/groupon/jenkins/dynamic/build/cause/GitHubPullRequestCause.java
+++ b/src/main/java/com/groupon/jenkins/dynamic/build/cause/GitHubPullRequestCause.java
@@ -45,6 +45,7 @@ public class GitHubPullRequestCause extends GithubCause {
     @Override
     public Map<String, String> getEnvVars() {
         Map vars = super.getEnvVars();
+        putIfNotNull(vars, "DOTCI_PULL_REQUEST_LABEL", getLabel());
         putIfNotNull(vars, "DOTCI_PULL_REQUEST_TARGET_BRANCH", getTargetBranch());
         putIfNotNull(vars, "DOTCI_PULL_REQUEST_SOURCE_BRANCH", getSourceBranch());
         return vars;
@@ -58,6 +59,10 @@ public class GitHubPullRequestCause extends GithubCause {
     @Override
     public String getName() {
         return "GITHUB_PULL_REQUEST";
+    }
+
+    public String getLabel() {
+        return label;
     }
 
     public String getTargetBranch() {


### PR DESCRIPTION
In order to provide an environment variable to get source organization and branch name I have exposed ```GitHubPullRequestCause.label``` in an environment variable named ```DOTCI_PULL_REQUEST_LABEL``` which uses similar naming to existing environment variables ```DOTCI_PULL_REQUEST_TARGET_BRANCH``` and ```DOTCI_PULL_REQUEST_SOURCE_BRANCH```.