### PR TITLE
ensure docker-compose pulls the latest image

### DIFF
--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -69,7 +69,7 @@ public class BuildConfiguration {
         appendCommands("before", shellCommands); //deprecated
         appendCommands("before_each", shellCommands);
 
-        shellCommands.add(String.format("docker-compose -f %s pull",fileName));
+        shellCommands.add(String.format("docker-compose -f %s build --pull",fileName));
         if (config.get("run") != null) {
             Map runConfig = (Map) config.get("run");
             String dockerComposeRunCommand = getDockerComposeRunCommand(dockerComposeContainerName, fileName, runConfig);


### PR DESCRIPTION
Thanks goes to Andrew Bloom for pointing this out.

Simple change from
> docker-compose pull

to
> docker-compose build --pull

#### Current DotCi build behavior
```
echo -e "foo:\n  build: ." > docker-compose.yml
echo "FROM centos:7" > Dockerfile
docker-compose pull
docker-compose run -T foo cat /etc/redhat-release
``` 
> CentOS Linux release 7.2.1511 (Core)

#### Latest image is not retrieved, the cached is used instead
```
echo "FROM centos:6" > Dockerfile
docker-compose pull
docker-compose run -T foo cat /etc/redhat-release
``` 
> CentOS Linux release 7.2.1511 (Core)

#### Confirmed the proposed patch solves the issue
```
docker-compose build --pull
docker-compose run -T foo cat /etc/redhat-release
```
> CentOS release 6.8 (Final)
