### PR TITLE
bash trap to docker-compose rm --all --force 

### DIFF
--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfiguration.java
@@ -64,7 +64,7 @@ public class BuildConfiguration {
         ShellCommands shellCommands = new ShellCommands();
         shellCommands.add(BuildConfiguration.getCheckoutCommands(dotCiEnvVars));
 
-        shellCommands.add(String.format("trap \"docker-compose -f %s kill; docker-compose -f %s rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",fileName,fileName));
+        shellCommands.add(String.format("trap \"docker-compose -f %s kill; docker-compose -f %s rm --all --force; exit\" PIPE QUIT INT HUP EXIT TERM",fileName,fileName));
 
         appendCommands("before", shellCommands); //deprecated
         appendCommands("before_each", shellCommands);

--- a/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
+++ b/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
@@ -48,7 +48,7 @@ public class BuildConfigurationTest {
   @Test
   public  void should_cleanup_after_test_run(){
     ShellCommands commands = getRunCommands();
-    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(5));
+    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm --all --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(5));
   }
 
   @Test
@@ -67,14 +67,14 @@ public class BuildConfigurationTest {
   @Test
   public void should_run_before_each_command_string(){
     ShellCommands commands = getRunCommands(ImmutableMap.of("before_each", "before_each cmd", "run", of("unit", "command", "integration", "integration")));
-    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(5));
+    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm --all --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(5));
     Assert.assertEquals("before_each cmd", commands.get(6));
   }
 
   @Test
   public void should_run_before_each_command_list(){
     ShellCommands commands = getRunCommands(ImmutableMap.of("before_each", ImmutableList.of("cmd 1", "cmd 2"), "run", of("unit", "command", "integration", "integration")));
-    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(5));
+    Assert.assertEquals("trap \"docker-compose -f docker-compose.yml kill; docker-compose -f docker-compose.yml rm --all --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(5));
     Assert.assertEquals("cmd 1", commands.get(6));
     Assert.assertEquals("cmd 2", commands.get(7));
   }
@@ -108,7 +108,7 @@ public class BuildConfigurationTest {
   @Test
   public void should_accept_alternative_docker_compose_file(){
     ShellCommands commands = getRunCommands(ImmutableMap.of("docker-compose-file", "./jenkins/docker-compose.yml", "run",  of("unit", "command")));
-    Assert.assertEquals("trap \"docker-compose -f ./jenkins/docker-compose.yml kill; docker-compose -f ./jenkins/docker-compose.yml rm -v --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(5));
+    Assert.assertEquals("trap \"docker-compose -f ./jenkins/docker-compose.yml kill; docker-compose -f ./jenkins/docker-compose.yml rm --all --force; exit\" PIPE QUIT INT HUP EXIT TERM",commands.get(5));
     Assert.assertEquals("docker-compose -f ./jenkins/docker-compose.yml pull",commands.get(6));
     Assert.assertEquals("export COMPOSE_CMD='docker-compose -f ./jenkins/docker-compose.yml run -T unit command'",commands.get(7));
     Assert.assertEquals(" set +e && hash unbuffer >/dev/null 2>&1 ;  if [ $? = 0 ]; then set -e && unbuffer $COMPOSE_CMD ;else set -e && $COMPOSE_CMD ;fi",commands.get(8));


### PR DESCRIPTION
Determined the proper solution for https://github.com/groupon/DotCi/issues/172
 is to change the bash trap to ``docker-compose rm --all --force``

This new flag is has been available and should be used to resolve https://github.com/docker/compose/issues/2791. However this does not resolve left over neworking like https://github.com/docker/compose/issues/2279