### PR TITLE
Multiple deploy keys added to repo preventing deploy keys from being added to slave

### DIFF
--- a/src/main/java/com/groupon/jenkins/github/services/GithubDeployKeyRepository.java
+++ b/src/main/java/com/groupon/jenkins/github/services/GithubDeployKeyRepository.java
@@ -45,9 +45,10 @@ public class GithubDeployKeyRepository extends MongoRepository {
     }
 
 
-    public void put(String url,DeployKeyPair keyPair) throws IOException {
+    public void put(String url, DeployKeyPair keyPair) throws IOException {
+        BasicDBObject query = new BasicDBObject("repo_url", url);
         BasicDBObject doc = new BasicDBObject("public_key", encrypt(keyPair.publicKey)).append("private_key",encrypt(keyPair.privateKey)).append("repo_url", url);
-        getCollection().insert(doc);
+        getCollection().update(query, doc, true, false);
     }
     protected DBCollection getCollection() {
         return getDatastore().getDB().getCollection("deploy_keys");

--- a/src/main/java/com/groupon/jenkins/github/services/GithubDeployKeyRepository.java
+++ b/src/main/java/com/groupon/jenkins/github/services/GithubDeployKeyRepository.java
@@ -62,7 +62,7 @@ public class GithubDeployKeyRepository extends MongoRepository {
 
     public boolean hasDeployKey(String repoUrl) {
         BasicDBObject query = new BasicDBObject("repo_url", repoUrl);
-        return getCollection().getCount(query) == 1;
+        return getCollection().getCount(query) > 0;
     }
     protected String encrypt(String value) {
         return  encryptionService.encrypt(value);


### PR DESCRIPTION
When deleting a project the old deploy_key is left behind and a new one is added if the repo is setup as a new job. So `hasDeployKey` was returning false and the pems were not getting added to the slave so the `git fetch` would fail.

Either change alone would fix the issue, but I don't think it hurts to have both. Let me know what you think. Thanks!