### PR TITLE
Update documentation for `skip`

### DIFF
--- a/docs/user-guide/DockerCompose.md
+++ b/docs/user-guide/DockerCompose.md
@@ -77,7 +77,7 @@ This is useful when combined with templating. Eg,
 ```yaml
 #only build master or pull request.
 <% if (DOTCI_BRANCH != 'master' && !DOTCI_PULL_REQUEST ) { %>
-skip:
+skip: true
 <% } %>
 run:
   ci: 


### PR DESCRIPTION
I was getting an error with `ERROR: Invalid .ci.yml. Required key run not specified.` until I realized that at some point the syntax for `skip` changed from `skip:` to `skip: true`.