### PR TITLE
Fixing Shell Varaible exports in BuildConfiguration and RunSection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ plugin:
     BOWER_ALLOW_ROOT: 'True'
     MAVEN_OPTS: "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000,suspend=n"
   command: mvn hpi:run
- 
+
 ci:
   image: maven:3
   volumes_from:

--- a/src/main/java/com/groupon/jenkins/buildtype/dockercompose/buildconfiguration/RunSection.java
+++ b/src/main/java/com/groupon/jenkins/buildtype/dockercompose/buildconfiguration/RunSection.java
@@ -76,7 +76,7 @@ public class RunSection {
     public List<String> getCommands(final String dockerComposeContainerName, final String fileName) {
         final List<String> commands = new ArrayList<>();
         final String dockerComposeRunCommand = getDockerComposeRunCommand(dockerComposeContainerName, fileName, this.config);
-        commands.add(format("export COMPOSE_CMD='%s'", dockerComposeRunCommand));
+        commands.add(format("COMPOSE_CMD='%s'; export $COMPOSE_CMD", dockerComposeRunCommand));
         commands.add(" set +e && hash unbuffer >/dev/null 2>&1 ;  if [ $? = 0 ]; then set -e && unbuffer $COMPOSE_CMD ;else set -e && $COMPOSE_CMD ;fi");
         return commands;
     }

--- a/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
+++ b/src/test/java/com/groupon/jenkins/buildtype/dockercompose/BuildConfigurationTest.java
@@ -32,6 +32,7 @@ import hudson.matrix.Combination;
 import org.junit.Assert;
 import org.junit.Test;
 
+
 import java.util.Map;
 
 import static com.google.common.collect.ImmutableMap.of;
@@ -61,7 +62,7 @@ public class BuildConfigurationTest {
     @Test
     public void should_run_cmd_from_ci_yml() {
         final ShellCommands commands = getRunCommands();
-        Assert.assertEquals("export COMPOSE_CMD='docker-compose -f docker-compose.yml run -T unit command'", commands.get(6));
+        Assert.assertEquals("COMPOSE_CMD='docker-compose -f docker-compose.yml run -T unit command'; export $COMPOSE_CMD", commands.get(6));
         Assert.assertEquals(" set +e && hash unbuffer >/dev/null 2>&1 ;  if [ $? = 0 ]; then set -e && unbuffer $COMPOSE_CMD ;else set -e && $COMPOSE_CMD ;fi", commands.get(7));
     }
 
@@ -108,7 +109,7 @@ public class BuildConfigurationTest {
     public void should_accept_alternative_docker_compose_file() {
         final ShellCommands commands = getRunCommands(ImmutableMap.of("docker-compose-file", "./jenkins/docker-compose.yml", "run", of("unit", "command")));
         Assert.assertEquals("docker-compose -f ./jenkins/docker-compose.yml pull", commands.get(5));
-        Assert.assertEquals("export COMPOSE_CMD='docker-compose -f ./jenkins/docker-compose.yml run -T unit command'", commands.get(6));
+        Assert.assertEquals("COMPOSE_CMD='docker-compose -f ./jenkins/docker-compose.yml run -T unit command'; export $COMPOSE_CMD", commands.get(6));
         Assert.assertEquals(" set +e && hash unbuffer >/dev/null 2>&1 ;  if [ $? = 0 ]; then set -e && unbuffer $COMPOSE_CMD ;else set -e && $COMPOSE_CMD ;fi", commands.get(7));
     }
 


### PR DESCRIPTION
The old style exports were problematic in the sense that shell commands
like $(pwd) or `pwd` weren't expanded before being passed to the COMPOSE_CMD variable
to be exported.