### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,40 +1,40 @@
-##2.6.3 (3/03/2015)
+## 2.6.3 (3/03/2015)
 - Add build header for new build page
 - Add cancel/restart button in the new ui
 
-##2.6.2(28/03/2015)
+## 2.6.2(28/03/2015)
  - Add console log with line numbers for the new UI
 
-##2.6.1(26/03/2015)
+## 2.6.1(26/03/2015)
  - Add option in build configuration to switch to new ui
 
-##2.6.0(17/03/2015)
+## 2.6.0(17/03/2015)
   - Replace `d3.js` with `chart.js` for build metrics.
   
-##2.6.0(16/03/2015)
+## 2.6.0(16/03/2015)
   - Optional new ui preview at ``<job-url>/newUi``
   
-##2.5.3(23/12/2014)
+## 2.5.3(23/12/2014)
  Bugfix:
   - Fix issue #98. Parallization error for docker sub builds.
-##2.5.2(16/12/2014)
+## 2.5.2(16/12/2014)
  Bugfix: 
   - Fix typo in github ouath url.
-##2.5.1(10/12/2014)
+## 2.5.1(10/12/2014)
  Bugfix: 
   - Request `write:repo_hook` in github scopes
 
-##2.5.0(10/12/2014)
+## 2.5.0(10/12/2014)
  Features:
   - Remove dependency on github oauth plugin. 
   - This Change lets dotci to be used with any(or no) authentication instead of mandating github oauth authentication.
  
-##2.4.0(01/12/2014)
+## 2.4.0(01/12/2014)
 Bugfix: 
  - Fix docker link container cleanup bug where linked containers were not being discarded if the build failed.
  - Store empty lists in database.
 
-##2.3.0(11/24/2014)
+## 2.3.0(11/24/2014)
 Features:
  - Add Commit History View for the `SHA` in current build.
  - Add support for private repos.
@@ -50,13 +50,13 @@ Bugfixes:
   - Fixes https://github.com/groupon/DotCi/issues/64.
   - Githook authenticates as `SYSTEM` user now.
 
-##2.2.0(11/19/2014)
+## 2.2.0(11/19/2014)
  - Changed serialization from XStream (XML) to Morphia (MongoDB/BSON)
     * Supports most classes that were previously serializable in XML
     * Does not currently support non-static inner classes
     * Includes [migration script] (./src/main/groovy/dotci_db_xml_morphia_migration.groovy) to assist transitioning from Mongo stored XML to BSON
 
-##2.0.0(09/05/2014)
+## 2.0.0(09/05/2014)
  - Introduced BuildType extension with two currently supported buildtypes
     * Install Packages
     * Docker Image

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-#Contributing
+# Contributing
 
 We welcome pull requests.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Brings ease of build configuration of cloud ci systems like travisci and ease of
 
 [http://groupon.github.io/DotCi](http://groupon.github.io/DotCi)
 
-###License
+### License
 ```
 The MIT License (MIT)
 

--- a/docs/development/DevelopmentSetup.md
+++ b/docs/development/DevelopmentSetup.md
@@ -15,7 +15,7 @@
 
 
     
-###Using Docker:
+### Using Docker:
 
 * Install docker: https://docs.docker.com/mac/started/
 * Install docker-compose: https://docs.docker.com/compose/install/

--- a/docs/installation/Installation.md
+++ b/docs/installation/Installation.md
@@ -27,7 +27,7 @@ following installed in addition to required Jenkins software:
 * [docker](https://www.docker.com)
 * [docker-compose](https://docs.docker.com/compose/install/)
 
-#MongoDB indexes
+# MongoDB indexes
 
 * Builds for project
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
